### PR TITLE
fix(ui): fix mock authentication logic

### DIFF
--- a/frontend/src/data/Mocks.ts
+++ b/frontend/src/data/Mocks.ts
@@ -145,11 +145,7 @@ export default [
     await delay(1000);
 
     // just check if the authentication header looks vaguely correct
-    if (
-      req.headers
-        .get("Authorization")
-        ?.indexOf("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.")
-    ) {
+    if (req.headers.get("Authorization")?.indexOf("Bearer ey") !== -1) {
       // respond with random ticket count
       const ticketCount = Math.floor(Math.random() * (2000 - 1000) + 1000);
       return res(ctx.json({ tickets: ticketCount }));
@@ -183,11 +179,7 @@ export default [
     await delay(1000);
 
     // just check if the authentication header looks vaguely correct
-    if (
-      req.headers
-        .get("Authorization")
-        ?.indexOf("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.")
-    ) {
+    if (req.headers.get("Authorization")?.indexOf("Bearer ey") !== -1) {
       const body: { prize_id: number } = await req.json();
       const prizeId = body.prize_id.toFixed();
 


### PR DESCRIPTION
Well, this is embarrassing. The mock backend has a logic bug in that it will reject correct JWT. The reason it was never caught is because the JWT generated by the mock backend itself is missing {"typ": "jwt"} key-value, so it always fails the check which puts it in the correct branch.

This PR fixes the logic bug and relaxes the check because the mock backend's role is to test the frontend, not to be correct implementation of the backend.