### PR TITLE
Backend: `/logs/http` self-logging loop bug fix

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -43,7 +43,7 @@ class JWTBearer(HTTPBearer):
                     f"Attempt to login with malformed JWT [{credentials.credentials}]"
                 )
                 raise HTTPException(status_code=403, detail="Invalid authentication.")
-            SecurityLog.info(
+            SecurityLog.debug(
                 f"[{jwt.get('name', None)}] logged in successfully with JWT[{jwt.get('sub', None)}]"
             )
             return jwt

--- a/backend/api/logs.py
+++ b/backend/api/logs.py
@@ -44,6 +44,11 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         request._receive = receive
 
     async def dispatch(self, request: Request, call_next):
+        # Do not log following endpoint since it will show logs of itself
+        # https://github.com/cs350-team4/ats/issues/11#issuecomment-1596346002
+        if request.url.path == "/logs/http":
+            return await call_next(request)
+
         time = time_ns()
         request_body = None
         try:

--- a/backend/api/logs.py
+++ b/backend/api/logs.py
@@ -109,6 +109,10 @@ class TransactionLog:
 
 class SecurityLog:
     @staticmethod
+    def debug(msg):
+        security_logger.debug(f"{time_ns()}::DEBUG:{msg}")
+
+    @staticmethod
     def info(msg):
         security_logger.info(f"{time_ns()}::INFO:{msg}")
 

--- a/backend/api/routers/logs.py
+++ b/backend/api/routers/logs.py
@@ -24,7 +24,8 @@ def read_logs(filename: str, lines: int) -> list[str]:
             lines_found = f.readlines()
             block_counter -= 1
 
-    return lines_found[-lines:]
+    # Remove newline at the end of the line
+    return [line.strip() for line in lines_found[-lines:]]
 
 
 @router.get("/http")

--- a/backend/api/tests/test_logs.py
+++ b/backend/api/tests/test_logs.py
@@ -25,3 +25,23 @@ def test_security_logs():
     assert 200 == get_security_logs(client, manager_tok).status_code
     assert 403 == get_security_logs(client, staff_tok).status_code
     assert 403 == get_security_logs(client, client_tok).status_code
+
+
+def test_http_no_self_log():
+    response1 = get_http_logs(client, manager_tok)
+    response2 = get_http_logs(client, manager_tok)
+
+    assert 200 == response1.status_code
+    assert 200 == response2.status_code
+
+    assert response1.text == response2.text
+
+
+def test_http_no_self_log_limit():
+    response1 = get_http_logs(client, manager_tok, limit=100)
+    response2 = get_http_logs(client, manager_tok, limit=100)
+
+    assert 200 == response1.status_code
+    assert 200 == response2.status_code
+
+    assert response1.text == response2.text


### PR DESCRIPTION
Fixes https://github.com/cs350-team4/ats/issues/11#issuecomment-1596346002

Also now newlines at the end of lines returned by `/logs` are stripped